### PR TITLE
Clone schema when setting debugobj

### DIFF
--- a/lib/Catalyst/TraitFor/Model/DBIC/Schema/QueryLog/AdoptPlack.pm
+++ b/lib/Catalyst/TraitFor/Model/DBIC/Schema/QueryLog/AdoptPlack.pm
@@ -28,8 +28,9 @@ sub infer_env_from {
 
 sub enable_dbic_querylogging {
   my ($self, $querylog) = @_;
-  $self->storage->debugobj($querylog);
-  $self->storage->debug(1);
+  my $clone = $self->clone;
+  $clone->storage->debugobj($querylog);
+  $clone->storage->debug(1);
 }
 
 sub die_missing_querylog {


### PR DESCRIPTION
The debug panel for me was giving incorrect results (either no queries, or queries from a different request within the same batch), until I altered it to clone the schema as mentioned in the manual for Plack::Middleware::Debug::DBIC::QueryLog: “We clone $schema to avoid associating the querylog with the global, persistant DBIC schema object.”
I'm not sure if this is the correct thing to do, but seems hopeful from that!